### PR TITLE
Pass in a TotalPowerAndTotalRolls instance to UnitBattleComparator (#…

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -61,10 +61,10 @@ public final class ProBattleUtils {
     final List<Unit> sortedUnitsList = new ArrayList<>(attackingUnits);
     sortedUnitsList.sort(
         new UnitBattleComparator(
-                false, //
                 proData.getUnitValueMap(),
-                TerritoryEffectHelper.getEffects(t),
-                data)
+                data,
+                CombatValue.buildMainCombatValue(
+                    List.of(), List.of(), false, data, TerritoryEffectHelper.getEffects(t)))
             .reversed());
     final int attackPower =
         PowerStrengthAndRolls.build(
@@ -150,7 +150,10 @@ public final class ProBattleUtils {
     final List<Unit> sortedUnitsList = new ArrayList<>(unitsThatCanFight);
     sortedUnitsList.sort(
         new UnitBattleComparator(
-                !attacking, proData.getUnitValueMap(), TerritoryEffectHelper.getEffects(t), data)
+                proData.getUnitValueMap(),
+                data,
+                CombatValue.buildMainCombatValue(
+                    List.of(), List.of(), !attacking, data, TerritoryEffectHelper.getEffects(t)))
             .reversed());
     final int myPower =
         PowerStrengthAndRolls.build(

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -201,7 +201,10 @@ public final class ProSortMoveOptionsUtils {
     for (final Territory t : territories) {
       final Collection<TerritoryEffect> effects = TerritoryEffectHelper.getEffects(t);
       final UnitBattleComparator comparator =
-          new UnitBattleComparator(false, proData.getUnitValueMap(), effects, data);
+          new UnitBattleComparator(
+              proData.getUnitValueMap(),
+              data,
+              CombatValue.buildMainCombatValue(List.of(), List.of(), false, data, effects));
 
       final List<Unit> defendingUnits =
           t.getUnitCollection().getMatches(Matches.enemyUnit(player, data));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -1398,10 +1398,14 @@ public class BattleTracker implements Serializable {
                 defenders, Matches.unitCanBeInBattle(false, !territory.isWater(), 1, true)));
     sortedUnitsList.sort(
         new UnitBattleComparator(
-                true,
                 TuvUtils.getCostsForTuv(bridge.getGamePlayer(), gameData),
-                TerritoryEffectHelper.getEffects(territory),
-                gameData)
+                gameData,
+                CombatValue.buildMainCombatValue(
+                    List.of(),
+                    List.of(),
+                    true,
+                    gameData,
+                    TerritoryEffectHelper.getEffects(territory)))
             .reversed());
     return sortedUnitsList;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -1,21 +1,19 @@
 package games.strategy.triplea.delegate.battle;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.TransportTracker;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Value;
 import org.triplea.java.collections.IntegerMap;
 
 // TODO: make the Comparator be serializable. To get there all class members need to be serializable
@@ -25,43 +23,42 @@ import org.triplea.java.collections.IntegerMap;
  * A comparator that sorts units in order from most likely to least likely to be chosen as a battle
  * loss.
  */
+@Value
+@Getter(AccessLevel.NONE)
 public class UnitBattleComparator implements Comparator<Unit> {
-  private final boolean defending;
-  private final IntegerMap<UnitType> costs;
-  private final boolean bonus;
-  private final boolean ignorePrimaryPower;
-  private final Collection<TerritoryEffect> territoryEffects;
-  private final Collection<UnitType> multiHitpointCanRepair = new HashSet<>();
+  IntegerMap<UnitType> costs;
+  boolean bonus;
+  boolean ignorePrimaryPower;
+  Collection<UnitType> multiHitpointCanRepair = new HashSet<>();
+  CombatValue combatValueCalculator;
+  CombatValue reversedCombatValueCalculator;
 
   public UnitBattleComparator(
-      final boolean defending,
       final IntegerMap<UnitType> costs,
-      final Collection<TerritoryEffect> territoryEffects,
-      final GameData data) {
-    this(defending, costs, territoryEffects, data, false, false);
+      final GameData data,
+      final CombatValue combatValueCalculator) {
+    this(costs, data, combatValueCalculator, false, false);
   }
 
   public UnitBattleComparator(
-      final boolean defending,
       final IntegerMap<UnitType> costs,
-      final Collection<TerritoryEffect> territoryEffects,
       final GameData data,
+      final CombatValue combatValueCalculator,
       final boolean bonus) {
-    this(defending, costs, territoryEffects, data, bonus, false);
+    this(costs, data, combatValueCalculator, bonus, false);
   }
 
   public UnitBattleComparator(
-      final boolean defending,
       final IntegerMap<UnitType> costs,
-      final Collection<TerritoryEffect> territoryEffects,
       final GameData data,
+      final CombatValue combatValueCalculator,
       final boolean bonus,
       final boolean ignorePrimaryPower) {
-    this.defending = defending;
     this.costs = costs;
+    this.combatValueCalculator = combatValueCalculator;
+    this.reversedCombatValueCalculator = combatValueCalculator.buildOppositeCombatValue();
     this.bonus = bonus;
     this.ignorePrimaryPower = ignorePrimaryPower;
-    this.territoryEffects = territoryEffects;
     if (Properties.getBattleshipsRepairAtEndOfRound(data)
         || Properties.getBattleshipsRepairAtBeginningOfRound(data)) {
       for (final UnitType ut : data.getUnitTypeList()) {
@@ -108,10 +105,8 @@ public class UnitBattleComparator implements Comparator<Unit> {
     final boolean multiHpCanRepair1 = multiHitpointCanRepair.contains(u1.getType());
     final boolean multiHpCanRepair2 = multiHitpointCanRepair.contains(u2.getType());
     if (!ignorePrimaryPower) {
-      final var combatModifiers =
-          CombatModifiers.builder().defending(defending).territoryEffects(territoryEffects).build();
-      int power1 = 8 * getUnitPowerForSorting(u1, combatModifiers);
-      int power2 = 8 * getUnitPowerForSorting(u2, combatModifiers);
+      int power1 = 8 * combatValueCalculator.getPower().getValue(u1);
+      int power2 = 8 * combatValueCalculator.getPower().getValue(u2);
       if (bonus) {
         if (subDestroyer1 && !subDestroyer2) {
           power1 += 4;
@@ -146,13 +141,8 @@ public class UnitBattleComparator implements Comparator<Unit> {
       }
     }
     {
-      final var combatModifiers =
-          CombatModifiers.builder()
-              .defending(!defending)
-              .territoryEffects(territoryEffects)
-              .build();
-      int power1reverse = 8 * getUnitPowerForSorting(u1, combatModifiers);
-      int power2reverse = 8 * getUnitPowerForSorting(u2, combatModifiers);
+      int power1reverse = 8 * reversedCombatValueCalculator.getPower().getValue(u1);
+      int power2reverse = 8 * reversedCombatValueCalculator.getPower().getValue(u2);
       if (bonus) {
         if (subDestroyer1 && !subDestroyer2) {
           power1reverse += 4;
@@ -200,54 +190,5 @@ public class UnitBattleComparator implements Comparator<Unit> {
       return -1;
     }
     return ua1.getMovement(u1.getOwner()) - ua2.getMovement(u2.getOwner());
-  }
-
-  @Builder
-  @Getter
-  public static class CombatModifiers {
-    @Builder.Default private final Collection<TerritoryEffect> territoryEffects = List.of();
-    private final boolean defending;
-  }
-
-  /**
-   * This returns the exact Power that a unit has according to what DiceRoll.rollDiceLowLuck() would
-   * give it. As such, it needs to exactly match DiceRoll, otherwise this method will become
-   * useless. It does NOT take into account SUPPORT. It DOES take into account ROLLS.
-   */
-  private int getUnitPowerForSorting(final Unit unit, final CombatModifiers combatModifiers) {
-    final GameData data = unit.getData();
-    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data);
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-
-    final GamePlayer owner = unit.getOwner();
-    final int rolls =
-        combatModifiers.defending ? ua.getDefenseRolls(owner) : ua.getAttackRolls(owner);
-    int strengthWithoutSupport = 0;
-    // Find the strength the unit has without support
-    // lhtr heavy bombers take best of n dice for both attack and defense
-    if (rolls > 1 && (lhtrBombers || ua.getChooseBestRoll())) {
-      strengthWithoutSupport =
-          combatModifiers.defending ? ua.getDefense(owner) : ua.getAttack(owner);
-      strengthWithoutSupport +=
-          TerritoryEffectHelper.getTerritoryCombatBonus(
-              unit.getType(), combatModifiers.territoryEffects, combatModifiers.defending);
-      // just add one like LL if we are LHTR bombers
-      strengthWithoutSupport =
-          Math.min(Math.max(strengthWithoutSupport + 1, 0), data.getDiceSides());
-    } else {
-      for (int i = 0; i < rolls; i++) {
-        final int tempStrength =
-            combatModifiers.defending ? ua.getDefense(owner) : ua.getAttack(owner);
-        strengthWithoutSupport +=
-            TerritoryEffectHelper.getTerritoryCombatBonus(
-                unit.getType(), combatModifiers.territoryEffects, combatModifiers.defending);
-        strengthWithoutSupport += Math.min(Math.max(tempStrength, 0), data.getDiceSides());
-      }
-    }
-
-    if (unit.getWasAmphibious()) {
-      strengthWithoutSupport += ua.getIsMarine();
-    }
-    return strengthWithoutSupport;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import games.strategy.triplea.delegate.power.calculator.UnitPowerStrengthAndRolls;
@@ -44,7 +43,6 @@ class CasualtyOrderOfLosses {
     @Nonnull CombatValue combatValue;
     @Nonnull Territory battlesite;
     @Nonnull IntegerMap<UnitType> costs;
-    @Nonnull CombatModifiers combatModifiers;
     @Nonnull GameData data;
   }
 
@@ -87,20 +85,18 @@ class CasualtyOrderOfLosses {
     final List<Unit> sortedUnitsList = new ArrayList<>(parameters.targetsToPickFrom);
     sortedUnitsList.sort(
         new UnitBattleComparator(
-                parameters.combatModifiers.isDefending(),
                 parameters.costs,
-                parameters.combatModifiers.getTerritoryEffects(),
                 parameters.data,
+                parameters.combatValue.buildWithNoUnitSupports(),
                 true,
                 false)
             .reversed());
     // Sort units starting with strongest so that support gets added to them first
     final UnitBattleComparator unitComparatorWithoutPrimaryPower =
         new UnitBattleComparator(
-            parameters.combatModifiers.isDefending(),
             parameters.costs,
-            parameters.combatModifiers.getTerritoryEffects(),
             parameters.data,
+            parameters.combatValue.buildWithNoUnitSupports(),
             true,
             true);
     final PowerStrengthAndRolls unitPowerAndRolls =
@@ -130,7 +126,7 @@ class CasualtyOrderOfLosses {
         }
         unitTypes.add(u.getType());
         // Find unit power
-        int power = originalUnitPowerAndRollsMap.get(u).calculatePower();
+        int power = originalUnitPowerAndRollsMap.get(u).getPower();
         // Add any support power that it provides to other units
         final IntegerMap<Unit> unitSupportPowerMapForUnit = unitSupportPowerMap.get(u);
         if (unitSupportPowerMapForUnit != null) {
@@ -151,13 +147,13 @@ class CasualtyOrderOfLosses {
               continue;
             }
             // Find supported unit power with support
-            final int powerWithSupport = strengthAndRolls.calculatePower();
+            final int powerWithSupport = strengthAndRolls.getPower();
             // Find supported unit power without support
 
             final int powerWithoutSupport =
                 strengthAndRolls
                     .subtractStrength(unitSupportPowerMapForUnit.getInt(supportedUnit))
-                    .calculatePower();
+                    .getPower();
             // Add the actual power provided by the support
             final int addedPower = powerWithSupport - powerWithoutSupport;
             power += addedPower;
@@ -173,12 +169,12 @@ class CasualtyOrderOfLosses {
               continue;
             }
             // Find supported unit power with support
-            final int powerWithSupport = strengthAndRolls.calculatePower();
+            final int powerWithSupport = strengthAndRolls.getPower();
             // Find supported unit power without support
             final int powerWithoutSupport =
                 strengthAndRolls
                     .subtractRolls(unitSupportRollsMap.get(u).getInt(supportedUnit))
-                    .calculatePower();
+                    .getPower();
             // Add the actual power provided by the support
             final int addedPower = powerWithSupport - powerWithoutSupport;
             power += addedPower;
@@ -269,7 +265,7 @@ class CasualtyOrderOfLosses {
         + "|"
         + parameters.battlesite.getName()
         + "|"
-        + parameters.combatModifiers.isDefending()
+        + parameters.combatValue.isDefending()
         + "|"
         + Objects.hashCode(targetTypes);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
@@ -282,11 +281,6 @@ public class CasualtySelector {
                 .targetsToPickFrom(targetsToPickFrom)
                 .player(player)
                 .combatValue(combatValue)
-                .combatModifiers(
-                    CombatModifiers.builder()
-                        .territoryEffects(combatValue.getTerritoryEffects())
-                        .defending(combatValue.isDefending())
-                        .build())
                 .battlesite(battlesite)
                 .costs(costs)
                 .data(data)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import java.util.Collection;
@@ -43,9 +42,6 @@ class AaDefenseCombatValue implements CombatValue {
   @Builder.Default
   Collection<Unit> enemyUnits = List.of();
 
-  @Getter(onMethod = @__({@Override}))
-  Collection<TerritoryEffect> territoryEffects = List.of();
-
   @Override
   public RollCalculator getRoll() {
     return new AaRoll(supportFromFriends, supportFromEnemies);
@@ -65,6 +61,33 @@ class AaDefenseCombatValue implements CombatValue {
   @Override
   public boolean isDefending() {
     return true;
+  }
+
+  @Override
+  public boolean chooseBestRoll(final Unit unit) {
+    return false;
+  }
+
+  @Override
+  public CombatValue buildWithNoUnitSupports() {
+    return AaDefenseCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .friendUnits(List.of())
+        .enemyUnits(List.of())
+        .build();
+  }
+
+  @Override
+  public CombatValue buildOppositeCombatValue() {
+    return AaOffenseCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(supportFromEnemies)
+        .supportFromEnemies(supportFromFriends)
+        .friendUnits(enemyUnits)
+        .enemyUnits(friendUnits)
+        .build();
   }
 
   @Value

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import java.util.Collection;
@@ -43,9 +42,6 @@ class AaOffenseCombatValue implements CombatValue {
   @Builder.Default
   Collection<Unit> enemyUnits = List.of();
 
-  @Getter(onMethod = @__({@Override}))
-  Collection<TerritoryEffect> territoryEffects = List.of();
-
   @Override
   public RollCalculator getRoll() {
     return new AaRoll(supportFromFriends, supportFromEnemies);
@@ -65,6 +61,33 @@ class AaOffenseCombatValue implements CombatValue {
   @Override
   public boolean isDefending() {
     return false;
+  }
+
+  @Override
+  public boolean chooseBestRoll(final Unit unit) {
+    return false;
+  }
+
+  @Override
+  public CombatValue buildWithNoUnitSupports() {
+    return AaOffenseCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .friendUnits(List.of())
+        .enemyUnits(List.of())
+        .build();
+  }
+
+  @Override
+  public CombatValue buildOppositeCombatValue() {
+    return AaDefenseCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(supportFromEnemies)
+        .supportFromEnemies(supportFromFriends)
+        .friendUnits(enemyUnits)
+        .enemyUnits(friendUnits)
+        .build();
   }
 
   @Value

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
@@ -121,6 +121,7 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   private void addUnits(final Collection<Unit> units) {
     final StrengthCalculator strengthCalculator = calculator.getStrength();
     final RollCalculator rollCalculator = calculator.getRoll();
+    final PowerCalculator powerCalculator = calculator.getPower();
     for (final Unit unit : units) {
       int strength = strengthCalculator.getStrength(unit).getValue();
       int rolls = rollCalculator.getRoll(unit).getValue();
@@ -133,9 +134,10 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
           UnitPowerStrengthAndRolls.builder()
               .strength(strength)
               .rolls(rolls)
+              .power(powerCalculator.getValue(unit))
+              .powerCalculator(powerCalculator)
               .diceSides(calculator.getDiceSides(unit))
-              // AA units never choose best roll
-              .chooseBestRoll(false)
+              .chooseBestRoll(calculator.chooseBestRoll(unit))
               .build());
     }
   }
@@ -206,10 +208,10 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
       if (totalBasicRolls + roll >= targetCount) {
         final int weakestBasicAaRolls = targetCount - totalBasicRolls;
         totalBasicRolls += weakestBasicAaRolls;
+        final UnitPowerStrengthAndRolls originalUnitData =
+            totalStrengthAndTotalRollsByUnit.get(unit);
         final UnitPowerStrengthAndRolls weakestBasicUnitData =
-            totalStrengthAndTotalRollsByUnit.get(unit).toBuilder()
-                .rolls(weakestBasicAaRolls)
-                .build();
+            originalUnitData.updateRolls(weakestBasicAaRolls);
         activeStrengthAndRolls.add(weakestBasicUnitData);
         // update the weakest rolling basic unit with the actual number of rolls it has
         totalStrengthAndTotalRollsByUnit.put(unit, weakestBasicUnitData);
@@ -225,10 +227,10 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
       final List<UnitPowerStrengthAndRolls> infinitePowerStrengthAndRolls = new ArrayList<>();
       bestInfiniteUnit.ifPresent(
           unit -> {
+            final UnitPowerStrengthAndRolls originalUnitData =
+                totalStrengthAndTotalRollsByUnit.get(unit);
             final UnitPowerStrengthAndRolls infiniteUnitData =
-                totalStrengthAndTotalRollsByUnit.get(unit).toBuilder()
-                    .rolls(targetCount - totalBasicRollsFinal)
-                    .build();
+                originalUnitData.updateRolls(targetCount - totalBasicRollsFinal);
             infinitePowerStrengthAndRolls.add(infiniteUnitData);
             // update the infinite unit with the actual number of rolls that it has
             totalStrengthAndTotalRollsByUnit.put(unit, infiniteUnitData);
@@ -251,7 +253,7 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
         continue;
       }
       totalStrengthAndTotalRollsByUnit.put(
-          mapEntry.getKey(), mapEntry.getValue().toBuilder().rolls(0).strength(0).build());
+          mapEntry.getKey(), mapEntry.getValue().toBuilder().rolls(0).strength(0).power(0).build());
     }
 
     return activeStrengthAndRolls;
@@ -283,9 +285,7 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
 
   @Override
   public int calculateTotalPower() {
-    return this.activeStrengthAndRolls.stream()
-        .mapToInt(UnitPowerStrengthAndRolls::calculatePower)
-        .sum();
+    return this.activeStrengthAndRolls.stream().mapToInt(UnitPowerStrengthAndRolls::getPower).sum();
   }
 
   @Override
@@ -306,6 +306,11 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   @Override
   public int getRolls(final Unit unit) {
     return totalStrengthAndTotalRollsByUnit.get(unit).getRolls();
+  }
+
+  @Override
+  public int getPower(final Unit unit) {
+    return totalStrengthAndTotalRollsByUnit.get(unit).getPower();
   }
 
   public boolean isSameStrength() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.power.calculator;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -36,9 +37,7 @@ public class BombardmentCombatValue implements CombatValue {
   @NonNull AvailableSupports supportFromFriends;
   @NonNull AvailableSupports supportFromEnemies;
 
-  @Getter(onMethod = @__({@Override}))
-  @NonNull
-  Collection<TerritoryEffect> territoryEffects;
+  @NonNull Collection<TerritoryEffect> territoryEffects;
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
@@ -69,6 +68,35 @@ public class BombardmentCombatValue implements CombatValue {
   @Override
   public boolean isDefending() {
     return false;
+  }
+
+  @Override
+  public boolean chooseBestRoll(final Unit unit) {
+    return Properties.getLhtrHeavyBombers(gameData) || unit.getUnitAttachment().getChooseBestRoll();
+  }
+
+  @Override
+  public CombatValue buildWithNoUnitSupports() {
+    return BombardmentCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .friendUnits(List.of())
+        .enemyUnits(List.of())
+        .territoryEffects(territoryEffects)
+        .build();
+  }
+
+  @Override
+  public CombatValue buildOppositeCombatValue() {
+    return BombardmentCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(supportFromEnemies)
+        .supportFromEnemies(supportFromFriends)
+        .friendUnits(enemyUnits)
+        .enemyUnits(friendUnits)
+        .territoryEffects(territoryEffects)
+        .build();
   }
 
   @Value

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
@@ -11,11 +11,16 @@ public interface CombatValue {
 
   StrengthCalculator getStrength();
 
+  default PowerCalculator getPower() {
+    return new PowerCalculator(
+        getGameData(), getStrength(), getRoll(), this::chooseBestRoll, this::getDiceSides);
+  }
+
   int getDiceSides(Unit unit);
 
   boolean isDefending();
 
-  Collection<TerritoryEffect> getTerritoryEffects();
+  boolean chooseBestRoll(Unit unit);
 
   GameData getGameData();
 
@@ -23,11 +28,15 @@ public interface CombatValue {
 
   Collection<Unit> getEnemyUnits();
 
+  CombatValue buildWithNoUnitSupports();
+
+  CombatValue buildOppositeCombatValue();
+
   static CombatValue buildMainCombatValue(
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
       final boolean defending,
-      final GameData data,
+      final GameData gameData,
       final Collection<TerritoryEffect> territoryEffects) {
 
     // Get all friendly supports
@@ -35,7 +44,7 @@ public interface CombatValue {
         AvailableSupports.getSortedSupport(
             new SupportCalculator(
                 allFriendlyUnitsAliveOrWaitingToDie,
-                data.getUnitTypeList().getSupportRules(),
+                gameData.getUnitTypeList().getSupportRules(),
                 defending,
                 true));
 
@@ -44,13 +53,13 @@ public interface CombatValue {
         AvailableSupports.getSortedSupport(
             new SupportCalculator(
                 allEnemyUnitsAliveOrWaitingToDie,
-                data.getUnitTypeList().getSupportRules(),
+                gameData.getUnitTypeList().getSupportRules(),
                 !defending,
                 false));
 
     return defending
         ? MainDefenseCombatValue.builder()
-            .gameData(data)
+            .gameData(gameData)
             .supportFromFriends(supportFromFriends)
             .supportFromEnemies(supportFromEnemies)
             .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
@@ -58,7 +67,7 @@ public interface CombatValue {
             .territoryEffects(territoryEffects)
             .build()
         : MainOffenseCombatValue.builder()
-            .gameData(data)
+            .gameData(gameData)
             .supportFromFriends(supportFromFriends)
             .supportFromEnemies(supportFromEnemies)
             .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
@@ -71,14 +80,14 @@ public interface CombatValue {
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
       final boolean defending,
-      final GameData data) {
+      final GameData gameData) {
 
     // Get all friendly supports
     final AvailableSupports supportFromFriends =
         AvailableSupports.getSortedSupport(
             new SupportCalculator(
                 allFriendlyUnitsAliveOrWaitingToDie, //
-                data.getUnitTypeList().getSupportAaRules(),
+                gameData.getUnitTypeList().getSupportAaRules(),
                 defending,
                 true));
 
@@ -87,20 +96,20 @@ public interface CombatValue {
         AvailableSupports.getSortedSupport(
             new SupportCalculator(
                 allEnemyUnitsAliveOrWaitingToDie, //
-                data.getUnitTypeList().getSupportAaRules(),
+                gameData.getUnitTypeList().getSupportAaRules(),
                 !defending,
                 false));
 
     return defending
         ? AaDefenseCombatValue.builder()
-            .gameData(data)
+            .gameData(gameData)
             .supportFromFriends(supportFromFriends)
             .supportFromEnemies(supportFromEnemies)
             .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
             .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
             .build()
         : AaOffenseCombatValue.builder()
-            .gameData(data)
+            .gameData(gameData)
             .supportFromFriends(supportFromFriends)
             .supportFromEnemies(supportFromEnemies)
             .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
@@ -111,7 +120,7 @@ public interface CombatValue {
   static CombatValue buildBombardmentCombatValue(
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final GameData data,
+      final GameData gameData,
       final Collection<TerritoryEffect> territoryEffects) {
 
     // Get all friendly supports
@@ -119,7 +128,7 @@ public interface CombatValue {
         AvailableSupports.getSortedSupport(
             new SupportCalculator(
                 allFriendlyUnitsAliveOrWaitingToDie,
-                data.getUnitTypeList().getSupportRules(),
+                gameData.getUnitTypeList().getSupportRules(),
                 false,
                 true));
 
@@ -128,12 +137,12 @@ public interface CombatValue {
         AvailableSupports.getSortedSupport(
             new SupportCalculator(
                 allEnemyUnitsAliveOrWaitingToDie,
-                data.getUnitTypeList().getSupportRules(),
+                gameData.getUnitTypeList().getSupportRules(),
                 true,
                 false));
 
     return BombardmentCombatValue.builder()
-        .gameData(data)
+        .gameData(gameData)
         .supportFromFriends(supportFromFriends)
         .supportFromEnemies(supportFromEnemies)
         .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -37,9 +38,7 @@ class MainDefenseCombatValue implements CombatValue {
   @NonNull AvailableSupports supportFromFriends;
   @NonNull AvailableSupports supportFromEnemies;
 
-  @Getter(onMethod = @__({@Override}))
-  @NonNull
-  Collection<TerritoryEffect> territoryEffects;
+  @NonNull Collection<TerritoryEffect> territoryEffects;
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
@@ -70,6 +69,35 @@ class MainDefenseCombatValue implements CombatValue {
   @Override
   public boolean isDefending() {
     return true;
+  }
+
+  @Override
+  public boolean chooseBestRoll(final Unit unit) {
+    return Properties.getLhtrHeavyBombers(gameData) || unit.getUnitAttachment().getChooseBestRoll();
+  }
+
+  @Override
+  public CombatValue buildWithNoUnitSupports() {
+    return MainDefenseCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .friendUnits(List.of())
+        .enemyUnits(List.of())
+        .territoryEffects(territoryEffects)
+        .build();
+  }
+
+  @Override
+  public CombatValue buildOppositeCombatValue() {
+    return MainOffenseCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(supportFromEnemies)
+        .supportFromEnemies(supportFromFriends)
+        .friendUnits(enemyUnits)
+        .enemyUnits(friendUnits)
+        .territoryEffects(territoryEffects)
+        .build();
   }
 
   @Value

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.power.calculator;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -36,9 +37,7 @@ class MainOffenseCombatValue implements CombatValue {
   @NonNull AvailableSupports supportFromFriends;
   @NonNull AvailableSupports supportFromEnemies;
 
-  @Getter(onMethod = @__({@Override}))
-  @NonNull
-  Collection<TerritoryEffect> territoryEffects;
+  @NonNull Collection<TerritoryEffect> territoryEffects;
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
@@ -69,6 +68,35 @@ class MainOffenseCombatValue implements CombatValue {
   @Override
   public boolean isDefending() {
     return false;
+  }
+
+  @Override
+  public boolean chooseBestRoll(final Unit unit) {
+    return Properties.getLhtrHeavyBombers(gameData) || unit.getUnitAttachment().getChooseBestRoll();
+  }
+
+  @Override
+  public CombatValue buildWithNoUnitSupports() {
+    return MainOffenseCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .friendUnits(List.of())
+        .enemyUnits(List.of())
+        .territoryEffects(territoryEffects)
+        .build();
+  }
+
+  @Override
+  public CombatValue buildOppositeCombatValue() {
+    return MainDefenseCombatValue.builder()
+        .gameData(gameData)
+        .supportFromFriends(supportFromEnemies)
+        .supportFromEnemies(supportFromFriends)
+        .friendUnits(enemyUnits)
+        .enemyUnits(friendUnits)
+        .territoryEffects(territoryEffects)
+        .build();
   }
 
   @Value

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerCalculator.java
@@ -1,0 +1,68 @@
+package games.strategy.triplea.delegate.power.calculator;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Unit;
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Value;
+
+/**
+ * Calculates the power of a unit
+ *
+ * <p>The power is defined as rolls * strength unless `chooseBestRoll` or `LHTR Bombers` are
+ * enabled. If those are enabled, then it is strength + (rolls - 1) * (diceSides / 6)
+ */
+@Value
+@Getter(AccessLevel.NONE)
+@AllArgsConstructor
+public class PowerCalculator {
+
+  GameData gameData;
+  StrengthCalculator strengthCalculator;
+  RollCalculator rollCalculator;
+  Function<Unit, Boolean> chooseBestRoll;
+  Function<Unit, Integer> getDiceSides;
+
+  public int getValue(final Unit unit) {
+    return getValue(
+        chooseBestRoll.apply(unit),
+        getDiceSides.apply(unit),
+        strengthCalculator.getStrength(unit).getValue(),
+        rollCalculator.getRoll(unit).getValue());
+  }
+
+  /**
+   * Allows calculations where the strength and/or rolls is different from what the unit actually
+   * has.
+   *
+   * <p>Useful for AA power calculations since AA units can fire less rolls than they have
+   * available.
+   */
+  int getValue(
+      final boolean chooseBestRoll,
+      final int diceSides,
+      final int unitStrength,
+      final int unitRolls) {
+    if (unitStrength <= 0 || unitRolls <= 0) {
+      return 0;
+    }
+    // Bonus is normally 1 for most games
+    final int extraRollBonus = Math.max(1, diceSides / 6);
+
+    int totalPower = 0;
+    if (unitRolls == 1) {
+      totalPower += unitStrength;
+    } else {
+      if (chooseBestRoll) {
+        // chooseBestRoll doesn't really make sense in LL. So instead,
+        // we will just add +1 onto the power to simulate the gains of having the best die picked.
+        totalPower += Math.min(unitStrength + extraRollBonus * (unitRolls - 1), diceSides);
+      } else {
+        totalPower += unitRolls * unitStrength;
+      }
+    }
+    return totalPower;
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.Properties;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -59,10 +58,9 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   }
 
   private void addUnits(final Collection<Unit> units) {
-    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(gameData);
-
     final StrengthCalculator strengthCalculator = calculator.getStrength();
     final RollCalculator rollCalculator = calculator.getRoll();
+    final PowerCalculator powerCalculator = calculator.getPower();
     for (final Unit unit : units) {
       int strength = strengthCalculator.getStrength(unit).getValue();
       int rolls = rollCalculator.getRoll(unit).getValue();
@@ -75,8 +73,10 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
           UnitPowerStrengthAndRolls.builder()
               .strength(strength)
               .rolls(rolls)
+              .power(powerCalculator.getValue(unit))
+              .powerCalculator(powerCalculator)
               .diceSides(calculator.getDiceSides(unit))
-              .chooseBestRoll(lhtrBombers || unit.getUnitAttachment().getChooseBestRoll())
+              .chooseBestRoll(calculator.chooseBestRoll(unit))
               .build());
     }
 
@@ -99,7 +99,7 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   @Override
   public int calculateTotalPower() {
     return totalStrengthAndTotalRollsByUnit.values().stream()
-        .mapToInt(UnitPowerStrengthAndRolls::calculatePower)
+        .mapToInt(UnitPowerStrengthAndRolls::getPower)
         .sum();
   }
 
@@ -123,5 +123,10 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   @Override
   public int getRolls(final Unit unit) {
     return totalStrengthAndTotalRollsByUnit.get(unit).getRolls();
+  }
+
+  @Override
+  public int getPower(final Unit unit) {
+    return totalStrengthAndTotalRollsByUnit.get(unit).getPower();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
@@ -12,4 +12,6 @@ public interface TotalPowerAndTotalRolls {
   int getStrength(Unit unit);
 
   int getRolls(Unit unit);
+
+  int getPower(Unit unit);
 }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1419,7 +1419,13 @@ class BattleCalculatorPanel extends JPanel {
       defenderUnitsTotalHitpoints.setText("HP: " + defenseHitPoints);
       final Collection<TerritoryEffect> territoryEffects = getTerritoryEffects();
       final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(getAttacker(), data);
-      attackers.sort(new UnitBattleComparator(false, costs, territoryEffects, data).reversed());
+      attackers.sort(
+          new UnitBattleComparator(
+                  costs,
+                  data,
+                  CombatValue.buildMainCombatValue(
+                      List.of(), List.of(), false, data, territoryEffects))
+              .reversed());
       if (isAmphibiousBattle()) {
         attackers.stream()
             .filter(Matches.unitIsLand())

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -21,6 +21,7 @@ import games.strategy.triplea.delegate.TechnologyDelegate;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.data.MustMoveWithDetails;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import games.strategy.triplea.ui.panels.map.MapSelectionListener;
@@ -684,7 +685,11 @@ class EditPanel extends ActionPanel {
             sortUnitsToRemove(units);
             units.sort(
                 new UnitBattleComparator(
-                        false, TuvUtils.getCostsForTuv(player, getData()), null, getData(), true)
+                        TuvUtils.getCostsForTuv(player, getData()),
+                        getData(),
+                        CombatValue.buildMainCombatValue(
+                            List.of(), List.of(), false, getData(), List.of()),
+                        true)
                     .reversed());
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();
@@ -758,7 +763,11 @@ class EditPanel extends ActionPanel {
             sortUnitsToRemove(units);
             units.sort(
                 new UnitBattleComparator(
-                        false, TuvUtils.getCostsForTuv(player, getData()), null, getData(), true)
+                        TuvUtils.getCostsForTuv(player, getData()),
+                        getData(),
+                        CombatValue.buildMainCombatValue(
+                            List.of(), List.of(), false, getData(), List.of()),
+                        true)
                     .reversed());
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -58,6 +58,7 @@ import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.data.FightBattleDetails;
 import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.triplea.delegate.data.TechRoll;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.remote.IEditDelegate;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
 import games.strategy.triplea.delegate.remote.IUserActionDelegate;
@@ -1419,10 +1420,14 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
             final List<Unit> units = new ArrayList<>(entry.getValue());
             units.sort(
                 new UnitBattleComparator(
-                        false,
                         TuvUtils.getCostsForTuv(units.get(0).getOwner(), data),
-                        TerritoryEffectHelper.getEffects(entry.getKey()),
                         data,
+                        CombatValue.buildMainCombatValue(
+                            List.of(),
+                            List.of(),
+                            false,
+                            data,
+                            TerritoryEffectHelper.getEffects(entry.getKey())),
                         true)
                     .reversed());
             possibleUnitsToAttackStringForm.put(entry.getKey().getName(), units);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
@@ -13,7 +13,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.List;
 import java.util.Map;
@@ -75,11 +74,6 @@ class CasualtyOrderOfLossesTest {
     when(territory.getName()).thenReturn("territory");
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(List.of())
-        .combatModifiers(
-            UnitBattleComparator.CombatModifiers.builder()
-                .defending(false)
-                .territoryEffects(List.of())
-                .build())
         .player(player)
         .combatValue(
             CombatValue.buildMainCombatValue(List.of(), List.of(), false, gameData, List.of()))

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
@@ -7,7 +7,6 @@ import static org.hamcrest.core.Is.is;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestDataBigWorld1942V3;
 import java.util.ArrayList;
@@ -62,8 +61,6 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
         });
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(amphibUnits)
-        .combatModifiers(
-            CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
         .player(testData.british)
         .combatValue(
             CombatValue.buildMainCombatValue(
@@ -192,8 +189,6 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(
             CasualtyOrderOfLosses.Parameters.builder()
                 .targetsToPickFrom(attackingUnits)
-                .combatModifiers(
-                    CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
                 .player(testData.british)
                 .combatValue(
                     CombatValue.buildMainCombatValue(
@@ -242,8 +237,6 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(
             CasualtyOrderOfLosses.Parameters.builder()
                 .targetsToPickFrom(attackingUnits)
-                .combatModifiers(
-                    CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
                 .player(testData.british)
                 .combatValue(
                     CombatValue.buildMainCombatValue(
@@ -263,8 +256,6 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(
             CasualtyOrderOfLosses.Parameters.builder()
                 .targetsToPickFrom(attackingUnits.subList(0, 3))
-                .combatModifiers(
-                    CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
                 .player(testData.british)
                 .combatValue(
                     CombatValue.buildMainCombatValue(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
@@ -17,7 +17,6 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.HeavyBomberAdvance;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -132,8 +131,6 @@ class CasualtyOrderOfLossesTestOnGlobal {
   private CasualtyOrderOfLosses.Parameters attackingWith(final Collection<Unit> units) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
-        .combatModifiers(
-            CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
         .player(BRITISH)
         .combatValue(CombatValue.buildMainCombatValue(List.of(), units, false, data, List.of()))
         .battlesite(FRANCE)
@@ -215,8 +212,6 @@ class CasualtyOrderOfLossesTestOnGlobal {
         });
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(amphibUnits)
-        .combatModifiers(
-            CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
         .player(BRITISH)
         .combatValue(
             CombatValue.buildMainCombatValue(List.of(), amphibUnits, false, data, List.of()))
@@ -296,8 +291,6 @@ class CasualtyOrderOfLossesTestOnGlobal {
   private CasualtyOrderOfLosses.Parameters defendingWith(final Collection<Unit> units) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
-        .combatModifiers(
-            CombatModifiers.builder().defending(true).territoryEffects(List.of()).build())
         .player(BRITISH)
         .combatValue(CombatValue.buildMainCombatValue(List.of(), units, true, data, List.of()))
         .battlesite(FRANCE)
@@ -364,9 +357,9 @@ class CasualtyOrderOfLossesTestOnGlobal {
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
 
     assertThat(result, hasSize(4));
-    assertThat(result.get(0).getType(), is(ARTILLERY));
+    assertThat(result.get(0).getType(), is(MARINE));
     assertThat(result.get(1).getType(), is(MARINE));
-    assertThat(result.get(2).getType(), is(MARINE));
+    assertThat(result.get(2).getType(), is(ARTILLERY));
     assertThat(result.get(3).getType(), is(TANK)); // attack at 3
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
@@ -11,7 +11,6 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -91,8 +90,6 @@ class CasualtyOrderOfLossesTestOnNapoleonic {
   private CasualtyOrderOfLosses.Parameters attackingWith(final Collection<Unit> units) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
-        .combatModifiers(
-            CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
         .player(BRITISH)
         .combatValue(CombatValue.buildMainCombatValue(List.of(), units, false, data, List.of()))
         .battlesite(NORMANDY)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
@@ -862,6 +862,10 @@ class TotalPowerAndTotalRollsTest {
       final StrengthCalculator strengthCalculator = mock(StrengthCalculator.class);
       when(strengthCalculator.getStrength(unit)).thenReturn(StrengthValue.of(6, 3));
       when(combatValue.getStrength()).thenReturn(strengthCalculator);
+      final PowerCalculator powerCalculator =
+          new PowerCalculator(
+              gameData, strengthCalculator, rollCalculator, (unit1) -> true, (unit1) -> 6);
+      when(combatValue.getPower()).thenReturn(powerCalculator);
       when(combatValue.getDiceSides(unit)).thenReturn(6);
       when(combatValue.getGameData()).thenReturn(gameData);
       final AaPowerStrengthAndRolls totalPowerAndTotalRolls =
@@ -1228,7 +1232,7 @@ class TotalPowerAndTotalRollsTest {
     @ParameterizedTest
     @MethodSource("bestRollSimulated")
     void lhtrIsSimulatedWithALittleExtraPower(
-        final int power,
+        final int strength,
         final int rolls,
         final int diceSides,
         final int expectedPower,
@@ -1237,11 +1241,12 @@ class TotalPowerAndTotalRollsTest {
           givenGameData().withDiceSides(diceSides).withLhtrHeavyBombers(true).build();
 
       final Unit unit = givenUnit("test", gameData);
-      unit.getUnitAttachment().setOffensiveAttackAa(power).setMaxAaAttacks(rolls);
+      unit.getUnitAttachment().setAttack(strength).setAttackRolls(rolls);
 
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
-              List.of(unit), CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              List.of(unit),
+              CombatValue.buildMainCombatValue(List.of(), List.of(), false, gameData, List.of()));
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(expectedPower));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(expectedRolls));
@@ -1261,7 +1266,7 @@ class TotalPowerAndTotalRollsTest {
     @ParameterizedTest
     @MethodSource("bestRollSimulated")
     void chooseBestRollIsSimulatedWithALittleExtraPower(
-        final int power,
+        final int strength,
         final int rolls,
         final int diceSides,
         final int expectedPower,
@@ -1269,14 +1274,12 @@ class TotalPowerAndTotalRollsTest {
       final GameData gameData = givenGameData().withDiceSides(diceSides).build();
 
       final Unit unit = givenUnit("test", gameData);
-      unit.getUnitAttachment()
-          .setOffensiveAttackAa(power)
-          .setMaxAaAttacks(rolls)
-          .setChooseBestRoll(true);
+      unit.getUnitAttachment().setAttack(strength).setAttackRolls(rolls).setChooseBestRoll(true);
 
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
-              List.of(unit), CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              List.of(unit),
+              CombatValue.buildMainCombatValue(List.of(), List.of(), false, gameData, List.of()));
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(expectedPower));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(expectedRolls));


### PR DESCRIPTION
…8098)

* Pass in a TotalPowerAndTotalRolls instance to UnitBattleComparator

This removes the duplicate power calculation from UnitBattleComparator.

* Create a power calculator and use that instead of UnitPowerStrengthAndRolls

* Don't change an input parameter

* Remove another unused variable

* Add java-doc, fix merge issues, replace buildNoSupportCombatValue


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
